### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
         args: [--autofix, --no-sort-keys]
         exclude: tests(/\w*)*/functional/|tests/input|tests(/.*)+/conftest.py|doc/data/messages|tests(/\w*)*data/|Pipfile.lock
 
-#-   repo: https://github.com/asottile/reorder-python-imports
-#    rev: v3.13.0
-#    hooks:
-#    -   id: reorder-python-imports
-#        args: [--py39-plus, --add-import, "from __future__ import annotations"]
-#        exclude: tests(/\w*)*/functional/|tests/input|tests(/.*)+/conftest.py|doc/data/messages|tests(/\w*)*data/
+-   repo: https://github.com/asottile/reorder-python-imports
+    rev: v0.0.1
+    hooks:
+    -   id: https://github.com/Tesla2000/black-compatible-reorder-python-imports
+        args: [--py39-plus, --add-import, "from __future__ import annotations", --retain-pre-import, "True"]
+        exclude: tests(/\w*)*/functional/|tests/input|tests(/.*)+/conftest.py|doc/data/messages|tests(/\w*)*data/
 
 -   repo: https://github.com/psf/black
     rev: 24.8.0


### PR DESCRIPTION
Hello,

I saw that you raised an issue regarding reorder-python-imports not being compatible with the current version of Black (https://github.com/asottile/reorder-python-imports/issues/389). Since the author has been unwilling to accept changes, I decided to publish a compatible version in the spirit of open source.

To ensure full compatibility, you’ll need to set the --retain-pre-import flag. Otherwise, it works exactly the same as the original implementation.